### PR TITLE
feat: add auto (random) selection mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,23 @@ A custom node for ComfyUI that makes prompt editing easier by allowing phrase sw
 
 ## Features
 
-- **Enable/disable phrases** with checkboxes
+- **Enable/disable phrases** with checkboxes (manual mode)
+- **Randomly pick phrases** with a seed (auto mode)
 - **Adjust prompt weights** using +/- buttons
 - **Combine with other prompts** using prefix input
 - **Customize output format** with delimiter and line break options
+
+## Modes
+
+The `mode` widget switches between two ways of selecting phrases:
+
+- **manual** (default): the original behaviour. Use the checkboxes to enable or
+  disable each phrase; every enabled line is included in the output.
+- **auto**: the checkboxes are hidden. On each run, `count` lines are picked at
+  random from the text (using `seed`), and the selection is shown at the bottom
+  of the node. `//` comment markers are ignored in this mode, so every non-empty
+  line is a candidate. The `count` and `seed` widgets stay visible in both modes
+  so `seed` can be connected to an external input.
 
 ## Installation
 
@@ -35,6 +48,11 @@ A custom node for ComfyUI that makes prompt editing easier by allowing phrase sw
      <img src="examples/output-format.png" alt="Output Format" width="400px" />
 
 ## Changelog
+
+### v1.4.0
+- Added `mode` widget with `manual` (checkboxes) and `auto` (random pick) modes
+- Added `count` and `seed` widgets for the auto mode random selection
+- The resolved selection is shown at the bottom of the node in auto mode
 
 ### v1.3.0
 - Added delimiter widget to separate phrases with comma, space, or nothing

--- a/nodes.py
+++ b/nodes.py
@@ -1,4 +1,5 @@
 import os
+import random
 
 
 class PromptPalette:
@@ -18,6 +19,33 @@ class PromptPalette:
                     "BOOLEAN",
                     {"default": True},
                 ),
+                "mode": (
+                    ["manual", "auto"],
+                    {
+                        "default": "manual",
+                        "tooltip": "manual: pick lines with the checkboxes. "
+                        "auto: pick 'count' random lines using 'seed'.",
+                    },
+                ),
+                "count": (
+                    "INT",
+                    {
+                        "default": 1,
+                        "min": 1,
+                        "max": 1000,
+                        "tooltip": "Auto mode only: how many lines to pick at random.",
+                    },
+                ),
+                "seed": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 0xFFFFFFFFFFFFFFFF,
+                        "control_after_generate": True,
+                        "tooltip": "Auto mode only: random seed for the selection.",
+                    },
+                ),
             },
             "optional": {"prefix": ("STRING", {"forceInput": True})},
         }
@@ -26,32 +54,25 @@ class PromptPalette:
     FUNCTION = "process"
     CATEGORY = "utils"
 
-    def process(self, text, delimiter, line_break, prefix=None):
+    def process(
+        self, text, delimiter, line_break, mode="manual", count=1, seed=0, prefix=None
+    ):
         lines = text.split("\n")
-        filtered_lines = []
-        for line in lines:
-            # Skip empty lines
-            if not line.strip():
-                continue
-            # Skip commented lines
-            if line.strip().startswith("//"):
-                continue
-            # Remove inline comments
-            if "//" in line:
-                line = line.split("//")[0].rstrip()
-            # Add suffix based on delimiter setting
-            if delimiter == "comma":
-                line = line + ", "
-            elif delimiter == "space":
-                line = line + " "
-            # "none" adds nothing
-            filtered_lines.append(line)
+
+        if mode == "auto":
+            phrases = self._collect_auto_phrases(lines, count, seed)
+        else:
+            phrases = self._collect_manual_phrases(lines)
+
+        # Add suffix based on delimiter setting
+        suffix = ", " if delimiter == "comma" else " " if delimiter == "space" else ""
+        phrases = [phrase + suffix for phrase in phrases]
 
         # Join lines based on line_break setting
         if line_break:
-            result = "\n".join(filtered_lines)
+            result = "\n".join(phrases)
         else:
-            result = "".join(filtered_lines)
+            result = "".join(phrases)
 
         # Add prefix if provided
         if prefix:
@@ -63,7 +84,55 @@ class PromptPalette:
             else:
                 result = prefix
 
-        return (result,)
+        # Expose the resolved selection to the frontend (shown in auto mode).
+        return {"ui": {"selected": [result]}, "result": (result,)}
+
+    def _collect_manual_phrases(self, lines):
+        """Manual mode: keep every non-empty line that is not commented out."""
+        phrases = []
+        for line in lines:
+            # Skip empty lines
+            if not line.strip():
+                continue
+            # Skip commented lines
+            if line.strip().startswith("//"):
+                continue
+            # Remove inline comments
+            if "//" in line:
+                line = line.split("//")[0].rstrip()
+            phrases.append(line)
+        return phrases
+
+    def _collect_auto_phrases(self, lines, count, seed):
+        """Auto mode: pick `count` random lines. Comments are ignored, so every
+        non-empty line is a candidate and the '//' markers are stripped out."""
+        candidates = []
+        for index, line in enumerate(lines):
+            phrase = self._strip_comments(line)
+            if phrase:
+                # Keep the original index so the picked lines stay in text order.
+                candidates.append((index, phrase))
+
+        if not candidates:
+            return []
+
+        pick_count = min(max(count, 0), len(candidates))
+        if pick_count <= 0:
+            return []
+
+        rng = random.Random(seed)
+        picked = rng.sample(candidates, pick_count)
+        picked.sort(key=lambda item: item[0])
+        return [phrase for _, phrase in picked]
+
+    def _strip_comments(self, line):
+        """Remove a leading '// ' marker and any inline '//' comment."""
+        stripped = line.strip()
+        if stripped.startswith("//"):
+            stripped = stripped[2:]
+        if "//" in stripped:
+            stripped = stripped.split("//")[0]
+        return stripped.strip()
 
 
 NODE_CLASS_MAPPINGS = {"PromptPalette": PromptPalette}

--- a/nodes.py
+++ b/nodes.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import random
 
@@ -48,6 +49,7 @@ class PromptPalette:
                 ),
             },
             "optional": {"prefix": ("STRING", {"forceInput": True})},
+            "hidden": {"unique_id": "UNIQUE_ID"},
         }
 
     RETURN_TYPES = ("STRING",)
@@ -55,12 +57,20 @@ class PromptPalette:
     CATEGORY = "utils"
 
     def process(
-        self, text, delimiter, line_break, mode="manual", count=1, seed=0, prefix=None
+        self,
+        text,
+        delimiter,
+        line_break,
+        mode="manual",
+        count=1,
+        seed=0,
+        prefix=None,
+        unique_id=None,
     ):
         lines = text.split("\n")
 
         if mode == "auto":
-            phrases = self._collect_auto_phrases(lines, count, seed)
+            phrases = self._collect_auto_phrases(lines, count, seed, unique_id)
         else:
             phrases = self._collect_manual_phrases(lines)
 
@@ -103,7 +113,7 @@ class PromptPalette:
             phrases.append(line)
         return phrases
 
-    def _collect_auto_phrases(self, lines, count, seed):
+    def _collect_auto_phrases(self, lines, count, seed, unique_id):
         """Auto mode: pick `count` random lines. Comments are ignored, so every
         non-empty line is a candidate and the '//' markers are stripped out."""
         candidates = []
@@ -120,10 +130,20 @@ class PromptPalette:
         if pick_count <= 0:
             return []
 
-        rng = random.Random(seed)
+        rng = random.Random(self._effective_seed(seed, unique_id))
         picked = rng.sample(candidates, pick_count)
         picked.sort(key=lambda item: item[0])
         return [phrase for _, phrase in picked]
+
+    def _effective_seed(self, seed, unique_id):
+        """Derive a per-node seed so that chaining several Prompt Palette nodes
+        with the same 'seed' value doesn't correlate their picks: random.Random
+        instances seeded identically consume the same underlying bit stream,
+        which biases combos when nodes share a seed (e.g. two palettes wired to
+        the same seed widget). Mixing in the node's unique_id keeps the result
+        deterministic per node while decorrelating it from other nodes."""
+        digest = hashlib.sha256(f"{seed}:{unique_id}".encode()).digest()
+        return int.from_bytes(digest[:8], "big")
 
     def _strip_comments(self, line):
         """Remove a leading '// ' marker and any inline '//' comment."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ComfyUI-PromptPalette"
 description = "A custom node that makes prompt editing easier by allowing phrase switching with just mouse operations."
-version = "1.3.0"
+version = "1.4.0"
 license = {file = "LICENSE"}
 
 [project.urls]

--- a/web/canvas_ui.js
+++ b/web/canvas_ui.js
@@ -3,6 +3,7 @@ import {
   calculateNodeHeight,
   findDelimiterWidget,
   findLineBreakWidget,
+  findModeWidget,
   findTextWidget,
   hideWidget,
   hideWidgetAndKeepSpace,
@@ -11,6 +12,7 @@ import {
   validateLineBreakValue,
 } from "./ui_utils.js";
 import { TextLines } from "./text_lines.js";
+import { SelectionDisplay } from "./selection_display.js";
 
 const CONFIG = {
   minNodeHeight: 80,
@@ -64,6 +66,15 @@ export function setupCanvasUI(nodeType, app) {
     }
     validateDelimiterValue(findDelimiterWidget(this));
     validateLineBreakValue(findLineBreakWidget(this));
+    this.__promptPaletteCanvasUI?.applyModeLayout();
+  };
+
+  const origOnExecuted = nodeType.prototype.onExecuted;
+  nodeType.prototype.onExecuted = function (message) {
+    if (origOnExecuted) {
+      origOnExecuted.apply(this, arguments);
+    }
+    this.__promptPaletteCanvasUI?.updateSelection(message);
   };
 
   const origOnDrawForeground = nodeType.prototype.onDrawForeground;
@@ -90,16 +101,19 @@ class PromptPaletteCanvasUI {
   #textWidget;
   #delimiterWidget;
   #lineBreakWidget;
+  #modeWidget;
   #app;
   #mode;
   #clickableAreas;
   #toggleButton;
+  #selectionDisplay;
 
   constructor(node, textWidget, app) {
     this.#node = node;
     this.#textWidget = textWidget;
     this.#delimiterWidget = findDelimiterWidget(node);
     this.#lineBreakWidget = findLineBreakWidget(node);
+    this.#modeWidget = findModeWidget(node);
     this.#app = app;
     this.#mode = PromptPaletteCanvasUI.MODE.DISPLAY;
     this.#clickableAreas = [];
@@ -109,14 +123,63 @@ class PromptPaletteCanvasUI {
     hideWidget(this.#delimiterWidget);
     hideWidget(this.#lineBreakWidget);
     this.#addToggleButton();
+    this.#selectionDisplay = new SelectionDisplay(node);
     this.#attachClickHandler();
+    this.#bindModeWidget();
+    this.applyModeLayout();
   }
 
   draw(ctx) {
+    // The checkbox palette only exists in manual mode.
+    if (this.#isAutoMode()) {
+      return;
+    }
     if (this.#mode !== PromptPaletteCanvasUI.MODE.DISPLAY) {
       return;
     }
     this.#drawCheckboxList(ctx);
+  }
+
+  // ========================================
+  // Selection Mode (manual / auto)
+  // ========================================
+  #isAutoMode() {
+    return this.#modeWidget ? this.#modeWidget.value === "auto" : false;
+  }
+
+  #bindModeWidget() {
+    if (!this.#modeWidget) return;
+    const origCallback = this.#modeWidget.callback;
+    this.#modeWidget.callback = (value, ...rest) => {
+      if (origCallback) {
+        origCallback.call(this.#modeWidget, value, ...rest);
+      }
+      this.applyModeLayout();
+    };
+  }
+
+  // Reconfigure which widgets are visible for the current selection mode.
+  applyModeLayout() {
+    if (this.#isAutoMode()) {
+      // Auto mode: no checkbox palette. Show the plain widgets so the pool can
+      // be edited, hide the Edit/Save toggle, and show the selection readout.
+      hideWidget(this.#toggleButton);
+      showWidget(this.#textWidget);
+      showWidget(this.#delimiterWidget);
+      showWidget(this.#lineBreakWidget);
+      this.#selectionDisplay.setVisible(true);
+    } else {
+      showWidget(this.#toggleButton);
+      this.#selectionDisplay.setVisible(false);
+      this.#updateWidgetVisibility();
+    }
+    this.#app.graph.setDirtyCanvas(true);
+  }
+
+  updateSelection(message) {
+    const selected = message?.selected;
+    const text = Array.isArray(selected) ? selected[0] : selected;
+    this.#selectionDisplay.setText(text);
   }
 
   // ========================================

--- a/web/dom_ui.js
+++ b/web/dom_ui.js
@@ -1,6 +1,7 @@
 import {
   findDelimiterWidget,
   findLineBreakWidget,
+  findModeWidget,
   findTextWidget,
   hideWidget,
   showWidget,
@@ -9,6 +10,7 @@ import {
 } from "./ui_utils.js";
 import { Line } from "./line.js";
 import { TextLines } from "./text_lines.js";
+import { SelectionDisplay } from "./selection_display.js";
 
 const CONFIG = {
   lineHeight: 24,
@@ -82,7 +84,16 @@ export function setupDomUI(nodeType, app) {
     }
     validateDelimiterValue(findDelimiterWidget(this));
     validateLineBreakValue(findLineBreakWidget(this));
+    this.__promptPaletteDomUI?.applyModeLayout();
     this.__promptPaletteDomUI?.requestRedraw();
+  };
+
+  const origOnExecuted = nodeType.prototype.onExecuted;
+  nodeType.prototype.onExecuted = function (message) {
+    if (origOnExecuted) {
+      origOnExecuted.apply(this, arguments);
+    }
+    this.__promptPaletteDomUI?.updateSelection(message);
   };
 }
 
@@ -101,6 +112,7 @@ class PromptPaletteDomUI {
   #textWidget;
   #delimiterWidget;
   #lineBreakWidget;
+  #modeWidget;
   #app;
   #mode;
   #rootContainer;
@@ -108,12 +120,14 @@ class PromptPaletteDomUI {
   #emptyMessage;
   #toggleButton;
   #rootWidget;
+  #selectionDisplay;
 
   constructor(node, textWidget, app) {
     this.#node = node;
     this.#textWidget = textWidget;
     this.#delimiterWidget = findDelimiterWidget(node);
     this.#lineBreakWidget = findLineBreakWidget(node);
+    this.#modeWidget = findModeWidget(node);
     this.#app = app;
     this.#mode = PromptPaletteDomUI.MODE.DISPLAY;
 
@@ -142,18 +156,79 @@ class PromptPaletteDomUI {
       PromptPaletteDomUI.EVENT.WEIGHT_MINUS,
       (event) => this.#handleRowWeightMinusEvent(event),
     );
+    this.#selectionDisplay = new SelectionDisplay(this.#node);
     this.#attachCollapseHook();
     this.#updateRootWidgetVisibility();
     hideWidget(this.#textWidget);
     hideWidget(this.#delimiterWidget);
     hideWidget(this.#lineBreakWidget);
+    this.#bindModeWidget();
+    this.applyModeLayout();
   }
 
   // Called after widget values are restored (workflow load, copy/paste).
   requestRedraw() {
+    if (this.#isAutoMode()) {
+      return;
+    }
     if (this.#mode === PromptPaletteDomUI.MODE.DISPLAY) {
       this.#buildDisplayRows();
     }
+  }
+
+  // ========================================
+  // Selection Mode (manual / auto)
+  // ========================================
+  #isAutoMode() {
+    return this.#modeWidget ? this.#modeWidget.value === "auto" : false;
+  }
+
+  #bindModeWidget() {
+    if (!this.#modeWidget) return;
+    const origCallback = this.#modeWidget.callback;
+    this.#modeWidget.callback = (value, ...rest) => {
+      if (origCallback) {
+        origCallback.call(this.#modeWidget, value, ...rest);
+      }
+      this.applyModeLayout();
+    };
+  }
+
+  // Reconfigure the UI for the current selection mode.
+  applyModeLayout() {
+    if (this.#isAutoMode()) {
+      // Auto mode: hide the checkbox palette, show the plain widgets so the
+      // pool can be edited, and reveal the selection readout.
+      this.#rootContainer.style.display = "none";
+      if (this.#rootWidget) {
+        this.#rootWidget.hidden = true;
+        if (this.#rootWidget.options) {
+          this.#rootWidget.options.hidden = true;
+        }
+      }
+      showWidget(this.#textWidget);
+      showWidget(this.#delimiterWidget);
+      showWidget(this.#lineBreakWidget);
+      this.#selectionDisplay.setVisible(true);
+    } else {
+      // Manual mode: back to the display palette (Edit/Save toggle + rows).
+      this.#mode = PromptPaletteDomUI.MODE.DISPLAY;
+      this.#toggleButton.textContent = "Edit";
+      hideWidget(this.#textWidget);
+      hideWidget(this.#delimiterWidget);
+      hideWidget(this.#lineBreakWidget);
+      this.#selectionDisplay.setVisible(false);
+      this.#updateRootWidgetVisibility();
+      this.#buildDisplayRows();
+    }
+    this.#refreshNodeWidgets();
+    this.#app.graph.setDirtyCanvas(true);
+  }
+
+  updateSelection(message) {
+    const selected = message?.selected;
+    const text = Array.isArray(selected) ? selected[0] : selected;
+    this.#selectionDisplay.setText(text);
   }
 
   // ========================================

--- a/web/selection_display.js
+++ b/web/selection_display.js
@@ -1,0 +1,59 @@
+// Read-only area that shows the phrases picked in auto mode.
+// Implemented as a DOM widget so it works in both Nodes 1.0 (Canvas) and
+// Nodes 2.0 (DOM) rendering modes.
+
+const DISPLAY_WIDGET_NAME = "promptpalette_selection";
+
+const PLACEHOLDER = "(run the prompt to see the auto selection)";
+
+export class SelectionDisplay {
+  #element;
+  #widget;
+
+  constructor(node) {
+    this.#element = this.#createElement();
+    this.#widget = node.addDOMWidget(
+      DISPLAY_WIDGET_NAME,
+      "promptpalette_selection",
+      this.#element,
+      {},
+    );
+    this.#widget.serialize = false;
+    if (this.#widget.options) {
+      this.#widget.options.margin = 0;
+    }
+    this.setVisible(false);
+  }
+
+  #createElement() {
+    const element = document.createElement("div");
+    const style = element.style;
+    style.width = "100%";
+    style.boxSizing = "border-box";
+    style.whiteSpace = "pre-wrap";
+    style.wordBreak = "break-word";
+    style.fontSize = "12px";
+    style.lineHeight = "1.4";
+    style.padding = "6px 8px";
+    style.borderRadius = "6px";
+    style.background =
+      "var(--comfy-input-bg, var(--component-node-widget-background, #222))";
+    style.color = "var(--input-text, var(--text-primary, #ddd))";
+    style.opacity = "0.85";
+    style.minHeight = "1.4em";
+    element.textContent = PLACEHOLDER;
+    return element;
+  }
+
+  setText(text) {
+    this.#element.textContent = text && text.length ? text : PLACEHOLDER;
+  }
+
+  setVisible(visible) {
+    this.#widget.hidden = !visible;
+    if (this.#widget.options) {
+      this.#widget.options.hidden = !visible;
+    }
+    this.#element.style.display = visible ? "" : "none";
+  }
+}

--- a/web/ui_utils.js
+++ b/web/ui_utils.js
@@ -10,6 +10,15 @@ export function findLineBreakWidget(node) {
   return findWidgetByName(node, "line_break");
 }
 
+export function findModeWidget(node) {
+  return findWidgetByName(node, "mode");
+}
+
+export function isAutoMode(node) {
+  const modeWidget = findModeWidget(node);
+  return modeWidget ? modeWidget.value === "auto" : false;
+}
+
 function findWidgetByName(node, name) {
   if (!node || !node.widgets) return null;
   for (const w of node.widgets) {


### PR DESCRIPTION
## What

Adds an **auto** selection mode alongside the existing manual (checkbox) mode, controlled by a new `mode` widget.

- **`mode`** widget: `manual` (default) / `auto`.
- **manual**: unchanged. Enable/disable phrases with the checkboxes; every enabled line is included.
- **auto**: on each run, `count` lines are picked at random from the text using `seed`. The checkbox palette is hidden and the resolved selection is shown at the bottom of the node (read-only).
- New **`count`** and **`seed`** widgets. `seed` uses `control_after_generate`, and both stay visible in manual mode too so `seed` can be connected to an external input.
- In auto mode, `//` comment markers are ignored (every non-empty line is a candidate) and stripped from the output, so switching between manual and auto has no side effects.

## Implementation

- `nodes.py`: shared line-parsing refactor; `random.Random(seed)` selection preserving text order; returns `{"ui": {"selected": [...]}, ...}` so the selection can be displayed.
- `web/selection_display.js` (new): read-only DOM widget for the selection readout, shared between the Canvas (Nodes 1.0) and DOM (Nodes 2.0) frontends.
- `web/canvas_ui.js` / `web/dom_ui.js`: mode switching, palette hidden in auto, `onExecuted` wiring.

## Backward compatibility

The new widgets are **appended** after the existing ones, so previously saved workflows keep their `widgets_values` alignment and behave exactly as before (default `manual`). Manual-mode output is unchanged.
